### PR TITLE
platformio CI and clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,google-*,clang-analyzer-*'
+WarningsAsErrors: ''

--- a/.github/workflows/platformIO_CI.yaml
+++ b/.github/workflows/platformIO_CI.yaml
@@ -1,0 +1,29 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install platformio
+    - name: Install libraries
+      run: |
+        bash CI_setup.sh
+    - name: Run PlatformIO
+      run: |
+        platformio run -d Testing/SPICY > testing_spicy_log.txt
+    - name: Upload log file
+      uses: actions/upload-artifact@v2
+      with:
+        name: SPICY_log
+        path: testing_spicy_log.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 .code-workspace
+dependencies

--- a/CI_setup.sh
+++ b/CI_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Script to install all non-standard libaries that your code depends on
+# (libraries you are using in your ARDUINO_LIBS environemnt variable)
+mkdir dependencies
+platformio lib --storage-dir dependencies install "Adafruit GFX Library"
+export ARDUINO_LIB=dependencies/

--- a/Testing/SPICY/platformio.ini
+++ b/Testing/SPICY/platformio.ini
@@ -10,5 +10,5 @@
 
 [env:teensy40]
 platform = teensy
-board = teensy40
+board = teensy41
 framework = arduino


### PR DESCRIPTION
## Headline Feature:

This PR contains CI to build platformio projects and install all dependencies needed for it. Clang-tidy has also been added.

closes #3 